### PR TITLE
Setting the MaxConcurrency on readConfig when is directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,6 +193,11 @@ func readConfig(configFile, configDir string) (c *Config, err error) {
 		if c.LogStream == nil && configTemp.LogStream != nil {
 			c.LogStream = configTemp.LogStream
 		}
+
+		// Read first MaxConcurrency only
+		if c.MaxConcurrency == 0 && configTemp.MaxConcurrency != 0 {
+			c.MaxConcurrency = configTemp.MaxConcurrency
+		}
 	}
 	return c, nil
 }


### PR DESCRIPTION
- Added getting the first MaxConcurrency of config files when directory is passed as a configuration source.
- Same procedure as LogStream, setting up on the first encounter of the variable.